### PR TITLE
Redirect to teddit before the request reaches Reddit

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,14 +27,6 @@
     "*://old.reddit.com/*"
   ],
 
-  "content_scripts": [
-    {
-      "matches": ["*://*.reddit.com/*"],
-      "js": ["teddit-redirect.js"],
-      "run_at": "document_start"
-    }
-  ],
-
    "options_ui": {
     "page": "options.html"
   }

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,14 @@
      }
   },
 
-  "permissions": ["storage"],
+  "permissions": [
+    "storage",
+    "webRequest",
+    "webRequestBlocking",
+    "*://reddit.com/*",
+    "*://www.reddit.com/*",
+    "*://old.reddit.com/*"
+  ],
 
   "content_scripts": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -3,15 +3,15 @@
   "manifest_version": 2,
   "version": "1.2.0",
   "name": "Teddit Redirect",
-  "description": "Redirect from Reddit to teddit automagically",
-  
+  "description": "Redirect from Reddit to teddit automatically",
+
   "homepage_url": "https://github.com/simon1573/teddit-redirect",
 
 
   "icons": {
     "240": "icons/redirect-240.png"
   },
-  
+
   "browser_specific_settings": {
     "gecko": {
       "id": "{fabaca19-4136-44b4-885d-9244adc75826}"

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,12 @@
     "*://old.reddit.com/*"
   ],
 
+  "background": {
+    "scripts": [
+        "teddit-redirect.js"
+    ]
+  },
+
    "options_ui": {
     "page": "options.html"
   }

--- a/teddit-redirect.js
+++ b/teddit-redirect.js
@@ -1,17 +1,51 @@
-function onError(error) {
-  console.log(`Error: ${error}`);
+/*
+Teddit Redirect
+*/
+async function tedditRedirectHandler(details) {
+
+	// Default URL of teddit instance
+	let tedditUrl = "https://teddit.net";
+
+	// Target URL of the captured webRequest event
+	const initialTargetUrl = details.url;
+
+	// Try to get the teddit instance URL from sync storage
+	const result = await browser.storage.sync.get("instance");
+
+	if(result.instance !== undefined) {
+		tedditUrl = "https://" + result.instance;
+	}
+
+	const rewrittenTargetUrl = initialTargetUrl.replace(
+		/^http(?:s)?:\/\/(?:(?:www|old).)?reddit.com(?:\/)?(.*)/i,
+		tedditUrl.replace(/(\/+)$/, "") + "/$1"
+	);
+
+	/*
+	Return a webRequest.BlockingResponse object.
+	https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse
+	*/
+	blockingResponse = {};
+	blockingResponse.redirectUrl = rewrittenTargetUrl;
+
+	return blockingResponse;
 }
 
-function onSettingsRead(item) {
-  let instance = "teddit.net";
-  if (item.instance) {
-    instance = item.instance;
-  }
-
-  const original_url = window.location.href
-  const new_url = original_url.replace('old.reddit.com', instance).replace(/(www\.)?reddit.com/, instance)
-  window.location.replace(new_url)
+/*
+Target URL filter for the webRequest.onBeforeRequest event listener.
+https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter
+*/
+webRequestFilter = {
+	urls: [
+		"*://reddit.com/*",
+		"*://www.reddit.com/*",
+		'*://old.reddit.com/*'
+	]
 }
 
-let getting = browser.storage.sync.get("instance");
-getting.then(onSettingsRead, onError);
+/*
+Add a webRequest.onBeforeRequest event listener.
+https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest
+*/
+browser.webRequest.onBeforeRequest.addListener(
+	tedditRedirectHandler, webRequestFilter, ["blocking"]);


### PR DESCRIPTION
Hello.

I recently stumbled over [teddit](https://codeberg.org/teddit/teddit) as a privacy-friendly frontend for Reddit and found this addon. I decided to give it a try and noticed that it does not prevent from leaking the initial request to Reddit which is usually the opposite of what a user of this addon would expect. Therefore, I began researching about the addon and somehow found your [blog post](https://utveckla.re/post/creating-an-addon-for-firefox/) that inspired me to improve the addon code in the way that users are redirected to the teddit instance before the actual request reaches Reddit's servers.

This is possible with background scripts which are executed in a more global context in contrary to the content scripts, which are executed when the request has already been sent. I quote from the [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts):
> Background scripts are loaded as soon as the extension is loaded and stay loaded until the extension is disabled or uninstalled. You can use any of the WebExtension APIs in the script, as long as you have requested the necessary permissions.

## Added permissions
So in addition to the existing `storage` permission, I've added the following permissions to `manifest.json`.

### API permissions
Quote from the [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest):
> To use the webRequest API for a given host, an extension must have the "webRequest" API permission and the host permission for that host. To use the "blocking" feature, the extension must also have the "webRequestBlocking" API permission.

- `webRequest`
- `webRequestBlocking`

### Host permissions
Quote from the [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions):
> Host permissions are specified as match patterns, and each pattern identifies a group of URLs for which the extension is requesting extra privileges. […] The extra privileges include: […]
> * the ability to receive events from the webrequest API for these hosts […]

- `*://reddit.com/*`
- `*://www.reddit.com/*`
- `*://old.reddit.com/*`

## Conclusion
Thanks for reading! Hope I was able to help make the addon better for all users! I've you have any questions regarding my code, please let me know. This is my first pull request and I hope I haven't made a mistake.